### PR TITLE
fix: use PAT for release-please to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   package:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Description

Use a Personal Access Token for release-please so that CI workflows
are triggered on release PRs. Without this, GITHUB_TOKEN-created PRs
never fire `pull_request` events, leaving required checks stuck.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] CI / build / tooling

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have added tests that prove my fix or feature works
- [x] All tests pass locally (`npm test`)
- [x] Linting passes (`npm run lint`)
- [ ] I have updated documentation if needed
