### PR TITLE
fix(core): export OfficeAdapter from public API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export { SharpAdapter } from './adapters/images/sharp-adapter';
 export { PdfAdapter } from './adapters/pdf/pdf-adapter';
 export { DocumentAdapter } from './adapters/document/document-adapter';
 export { OcrAdapter } from './adapters/ocr/ocr-adapter';
+export { OfficeAdapter } from './adapters/office/office-adapter';
 export { ConfigManager } from './config/config-manager';
 export { listPresets, getPreset } from './presets/image-presets';
 export { logger } from './logger';

--- a/packages/core/test/public-api.test.ts
+++ b/packages/core/test/public-api.test.ts
@@ -1,0 +1,9 @@
+import { OfficeAdapter } from '../src';
+
+describe('public API', () => {
+  it('exports OfficeAdapter', () => {
+    const adapter = new OfficeAdapter();
+
+    expect(adapter.name).toBe('office');
+  });
+});


### PR DESCRIPTION
## Summary
- exports OfficeAdapter from the core package public API
- adds a public API test that imports OfficeAdapter from ../src

Closes #21.

## Verification
- npm test --workspace @fileconverter/core -- public-api.test.ts
- npm test
- npm run build