### PR TITLE
feat(core): add SVG image input support

### DIFF
--- a/packages/core/src/adapters/images/sharp-adapter.ts
+++ b/packages/core/src/adapters/images/sharp-adapter.ts
@@ -7,7 +7,7 @@ import logger from '../../logger';
 
 export class SharpAdapter extends BaseAdapter {
   readonly name = 'sharp';
-  readonly supportedInputFormats = ['heic', 'jpg', 'jpeg', 'png', 'webp', 'tiff', 'bmp', 'gif'];
+  readonly supportedInputFormats = ['heic', 'jpg', 'jpeg', 'png', 'webp', 'tiff', 'bmp', 'gif', 'svg'];
   readonly supportedOutputFormats = ['jpg', 'jpeg', 'png', 'webp', 'tiff'];
 
   async convert(

--- a/packages/core/src/file-detector.ts
+++ b/packages/core/src/file-detector.ts
@@ -13,6 +13,7 @@ const SUPPORTED_FORMATS = {
   'image/tiff': { ext: 'tiff', supported: true },
   'image/bmp': { ext: 'bmp', supported: true },
   'image/gif': { ext: 'gif', supported: true },
+  'image/svg+xml': { ext: 'svg', supported: true },
   
   // Document formats
   'application/pdf': { ext: 'pdf', supported: true },
@@ -39,6 +40,7 @@ const EXTENSION_TO_MIME: Record<string, string> = {
   'tif': 'image/tiff',
   'bmp': 'image/bmp',
   'gif': 'image/gif',
+  'svg': 'image/svg+xml',
   'pdf': 'application/pdf',
   'md': 'text/markdown',
   'html': 'text/html',

--- a/packages/core/test/adapters/sharp-adapter.test.ts
+++ b/packages/core/test/adapters/sharp-adapter.test.ts
@@ -34,6 +34,11 @@ describe('SharpAdapter', () => {
       expect(result).toBe(true);
     });
 
+    it('should support SVG to PNG conversion', () => {
+      const result = adapter.canHandle('svg', 'png');
+      expect(result).toBe(true);
+    });
+
     it('should not support unsupported conversions', () => {
       const result = adapter.canHandle('xyz', 'abc');
       expect(result).toBe(false);
@@ -87,6 +92,31 @@ describe('SharpAdapter', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
     });
+
+    it('should convert SVG to PNG', async () => {
+      const svgInputPath = getTestFilePath('sharp-test.svg');
+      const pngOutputPath = getTestFilePath('sharp-test-output.png');
+
+      fs.writeFileSync(
+        svgInputPath,
+        '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="red"/></svg>'
+      );
+
+      const plan = {
+        inputPath: svgInputPath,
+        outputPath: pngOutputPath,
+        inputFormat: 'svg',
+        outputFormat: 'png',
+        supported: true
+      };
+
+      const result = await adapter.convert(plan, {});
+
+      expect(result.success).toBe(true);
+      expect(fs.existsSync(pngOutputPath)).toBe(true);
+      expect(fs.statSync(pngOutputPath).size).toBeGreaterThan(0);
+      expect(result.metadata?.format).toBe('png');
+    }, 30000);
   });
 
   describe('supportedFormats', () => {
@@ -94,6 +124,7 @@ describe('SharpAdapter', () => {
       expect(adapter.supportedInputFormats).toContain('png');
       expect(adapter.supportedInputFormats).toContain('jpg');
       expect(adapter.supportedInputFormats).toContain('webp');
+      expect(adapter.supportedInputFormats).toContain('svg');
     });
 
     it('should return supported output formats', () => {

--- a/packages/core/test/file-detector.test.ts
+++ b/packages/core/test/file-detector.test.ts
@@ -1,0 +1,24 @@
+import { createTestFile } from './setup';
+import { detectFileType, getSupportedFormats, isSupportedFormat } from '../src/file-detector';
+import { fileTypeFromFile } from 'file-type';
+
+describe('file-detector', () => {
+  it('should support SVG files by extension', async () => {
+    (fileTypeFromFile as jest.Mock).mockResolvedValueOnce(undefined);
+
+    const filePath = createTestFile(
+      'detector-test.svg',
+      '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>'
+    );
+
+    const result = await detectFileType(filePath);
+
+    expect(result).toEqual({
+      ext: 'svg',
+      mime: 'image/svg+xml',
+      supported: true,
+    });
+    expect(isSupportedFormat('svg')).toBe(true);
+    expect(getSupportedFormats()).toContain('svg');
+  });
+});


### PR DESCRIPTION
## Summary
- add SVG MIME and extension support to file detection
- allow SharpAdapter to route SVG image inputs to existing raster outputs
- add tests for SVG detection and SVG to PNG conversion

## Tests
- npm test
- npm run lint
- npm run build