### PR TITLE
fix: preserve structure in office PDF conversion

### DIFF
--- a/packages/core/src/adapters/document/document-adapter.ts
+++ b/packages/core/src/adapters/document/document-adapter.ts
@@ -7,6 +7,7 @@ import logger from '../../logger';
 import {
   stripHtml,
   stripMarkdown,
+  renderHtmlToPdf,
   renderTextToPdf,
   wrapInHtmlDocument,
   htmlToMarkdown,
@@ -57,7 +58,7 @@ export class DocumentAdapter extends BaseAdapter {
 
       if (outputFmt === 'pdf') {
         logger.warn(
-          'PDF output uses basic text rendering. Formatting, images, and tables will not be preserved. For best results, convert to HTML instead.'
+          'PDF output preserves basic headings, paragraphs, lists, tables, and embedded images. Complex layouts and CSS are not preserved.'
         );
         await this.convertToPdf(inputContent, inputFmt, plan.outputPath);
       } else if (outputFmt === 'html' || outputFmt === 'htm') {
@@ -102,14 +103,12 @@ export class DocumentAdapter extends BaseAdapter {
   }
 
   private convertToPdf(content: string, inputFormat: string, outputPath: string): Promise<void> {
-    let textContent = content;
     if (inputFormat === 'md' || inputFormat === 'markdown') {
-      textContent = stripMarkdown(content);
-    } else if (inputFormat === 'html' || inputFormat === 'htm') {
-      textContent = stripHtml(content);
+      return renderHtmlToPdf(marked.parse(content, { async: false }) as string, outputPath);
     }
+    if (inputFormat === 'html' || inputFormat === 'htm') return renderHtmlToPdf(content, outputPath);
 
-    return renderTextToPdf(textContent, outputPath);
+    return renderTextToPdf(content, outputPath);
   }
 
   private convertToHtml(content: string, inputFormat: string, outputPath: string): void {

--- a/packages/core/src/adapters/document/html-renderers.ts
+++ b/packages/core/src/adapters/document/html-renderers.ts
@@ -83,9 +83,22 @@ function textContent(node: any): string {
   return Array.from(node.childNodes || []).map(textContent).join('');
 }
 
-function renderInline(doc: PDFDocument, node: any): void {
+type InlineFont = 'Helvetica' | 'Helvetica-Bold' | 'Helvetica-Oblique' | 'Helvetica-BoldOblique';
+
+function inlineFont(tag: string, inheritedFont: InlineFont): InlineFont {
+  const bold = inheritedFont === 'Helvetica-Bold' || inheritedFont === 'Helvetica-BoldOblique'
+    || tag === 'strong' || tag === 'b';
+  const italic = inheritedFont === 'Helvetica-Oblique' || inheritedFont === 'Helvetica-BoldOblique'
+    || tag === 'em' || tag === 'i';
+  if (bold && italic) return 'Helvetica-BoldOblique';
+  if (bold) return 'Helvetica-Bold';
+  if (italic) return 'Helvetica-Oblique';
+  return 'Helvetica';
+}
+
+function renderInline(doc: PDFDocument, node: any, inheritedFont: InlineFont = 'Helvetica'): void {
   if (node.nodeType === 3) {
-    doc.text(node.data || '', { continued: true });
+    doc.font(inheritedFont).text(node.data || '', { continued: true });
     return;
   }
 
@@ -95,14 +108,8 @@ function renderInline(doc: PDFDocument, node: any): void {
     return;
   }
 
-  const previousFont = tag === 'strong' || tag === 'b'
-    ? 'Helvetica-Bold'
-    : tag === 'em' || tag === 'i'
-      ? 'Helvetica-Oblique'
-      : 'Helvetica';
-  doc.font(previousFont);
-  for (const child of Array.from(node.childNodes || [])) renderInline(doc, child);
-  doc.font('Helvetica');
+  const childFont = inlineFont(tag, inheritedFont);
+  for (const child of Array.from(node.childNodes || [])) renderInline(doc, child, childFont);
 }
 
 function renderTable(doc: PDFDocument, table: any, width: number): void {
@@ -113,6 +120,7 @@ function renderTable(doc: PDFDocument, table: any, width: number): void {
     const cellWidth = width / cells.length;
     const y = doc.y;
     const values = cells.map(textContent);
+    doc.font('Helvetica').fontSize(10);
     const heights = values.map((value) => doc.heightOfString(value, { width: cellWidth - 10 }));
     const rowHeight = Math.max(...heights, 14) + 10;
     cells.forEach((cell, index) => {
@@ -166,12 +174,18 @@ export function renderHtmlToPdf(html: string, outputPath: string): Promise<void>
   return new Promise((resolve, reject) => {
     const doc = new PDFDocument({ margin: 50 });
     const stream = fs.createWriteStream(outputPath);
-    doc.pipe(stream);
-    const root = new DOMParser().parseFromString(`<root>${html}</root>`, 'text/html').documentElement;
-    const width = doc.page.width - 100;
-    for (const child of Array.from(root.childNodes || [])) renderBlock(doc, child, width);
-    doc.end();
     stream.on('finish', resolve);
     stream.on('error', reject);
+    doc.on('error', reject);
+
+    try {
+      doc.pipe(stream);
+      const root = new DOMParser().parseFromString(`<root>${html}</root>`, 'text/html').documentElement;
+      const width = doc.page.width - 100;
+      for (const child of Array.from(root.childNodes || [])) renderBlock(doc, child, width);
+      doc.end();
+    } catch (error) {
+      reject(error);
+    }
   });
 }

--- a/packages/core/src/adapters/document/html-renderers.ts
+++ b/packages/core/src/adapters/document/html-renderers.ts
@@ -1,3 +1,4 @@
+import { DOMParser } from '@xmldom/xmldom';
 import { marked } from 'marked';
 import PDFDocument from 'pdfkit';
 import sanitizeHtml from 'sanitize-html';
@@ -77,7 +78,100 @@ export function htmlToMarkdown(html: string): string {
  * @param outputPath - Destination file path
  * @returns Promise that resolves when the PDF is written
  */
+function textContent(node: any): string {
+  if (node.nodeType === 3) return node.data || '';
+  return Array.from(node.childNodes || []).map(textContent).join('');
+}
+
+function renderInline(doc: PDFDocument, node: any): void {
+  if (node.nodeType === 3) {
+    doc.text(node.data || '', { continued: true });
+    return;
+  }
+
+  const tag = (node.localName || node.nodeName || '').toLowerCase();
+  if (tag === 'br') {
+    doc.text('', { continued: false });
+    return;
+  }
+
+  const previousFont = tag === 'strong' || tag === 'b'
+    ? 'Helvetica-Bold'
+    : tag === 'em' || tag === 'i'
+      ? 'Helvetica-Oblique'
+      : 'Helvetica';
+  doc.font(previousFont);
+  for (const child of Array.from(node.childNodes || [])) renderInline(doc, child);
+  doc.font('Helvetica');
+}
+
+function renderTable(doc: PDFDocument, table: any, width: number): void {
+  const rows = Array.from(table.getElementsByTagName('tr')) as any[];
+  for (const row of rows) {
+    const cells = Array.from(row.childNodes || []).filter((cell: any) => ['td', 'th'].includes((cell.localName || '').toLowerCase())) as any[];
+    if (!cells.length) continue;
+    const cellWidth = width / cells.length;
+    const y = doc.y;
+    const values = cells.map(textContent);
+    const heights = values.map((value) => doc.heightOfString(value, { width: cellWidth - 10 }));
+    const rowHeight = Math.max(...heights, 14) + 10;
+    cells.forEach((cell, index) => {
+      doc.rect(50 + index * cellWidth, y, cellWidth, rowHeight).stroke();
+      doc.font((cell.localName || '').toLowerCase() === 'th' ? 'Helvetica-Bold' : 'Helvetica')
+        .fontSize(10)
+        .text(values[index], 55 + index * cellWidth, y + 5, { width: cellWidth - 10, lineBreak: true });
+    });
+    doc.y = y + rowHeight;
+  }
+  doc.font('Helvetica').moveDown(0.5);
+}
+
+function renderImage(doc: PDFDocument, image: any, width: number): void {
+  const source = image.getAttribute('src') || '';
+  const match = /^data:image\/(png|jpeg|jpg);base64,(.+)$/i.exec(source);
+  if (!match) return;
+  doc.image(Buffer.from(match[2], 'base64'), { fit: [width, 360], align: 'center' });
+  doc.moveDown(0.5);
+}
+
+function renderBlock(doc: PDFDocument, node: any, width: number): void {
+  if (node.nodeType === 3) {
+    if ((node.data || '').trim()) doc.font('Helvetica').fontSize(12).text(node.data.trim());
+    return;
+  }
+
+  const tag = (node.localName || node.nodeName || '').toLowerCase();
+  if (tag === 'h1' || tag === 'h2' || tag === 'h3') {
+    const size = tag === 'h1' ? 22 : tag === 'h2' ? 18 : 14;
+    doc.font('Helvetica-Bold').fontSize(size).text(textContent(node), { width });
+    doc.font('Helvetica').moveDown(0.5);
+  } else if (tag === 'p') {
+    doc.font('Helvetica').fontSize(12);
+    for (const child of Array.from(node.childNodes || [])) renderInline(doc, child);
+    doc.text('', { continued: false });
+    doc.moveDown(0.5);
+  } else if (tag === 'ul' || tag === 'ol') {
+    const items = Array.from(node.childNodes || []).filter((child: any) => (child.localName || '').toLowerCase() === 'li') as any[];
+    items.forEach((item, index) => {
+      doc.font('Helvetica').fontSize(12).text(`${tag === 'ol' ? `${index + 1}.` : '-'} ${textContent(item)}`, { width, indent: 12 });
+    });
+    doc.moveDown(0.5);
+  } else if (tag === 'table') renderTable(doc, node, width);
+  else if (tag === 'img') renderImage(doc, node, width);
+  else if (tag === 'hr') { doc.moveDown(); }
+  else for (const child of Array.from(node.childNodes || [])) renderBlock(doc, child, width);
+}
+
 export function renderHtmlToPdf(html: string, outputPath: string): Promise<void> {
-  const textContent = stripHtml(html);
-  return renderTextToPdf(textContent, outputPath);
+  return new Promise((resolve, reject) => {
+    const doc = new PDFDocument({ margin: 50 });
+    const stream = fs.createWriteStream(outputPath);
+    doc.pipe(stream);
+    const root = new DOMParser().parseFromString(`<root>${html}</root>`, 'text/html').documentElement;
+    const width = doc.page.width - 100;
+    for (const child of Array.from(root.childNodes || [])) renderBlock(doc, child, width);
+    doc.end();
+    stream.on('finish', resolve);
+    stream.on('error', reject);
+  });
 }

--- a/packages/core/src/adapters/document/html-renderers.ts
+++ b/packages/core/src/adapters/document/html-renderers.ts
@@ -72,8 +72,24 @@ export function htmlToMarkdown(html: string): string {
   return turndown.turndown(html);
 }
 
+const PDF_ALLOWED_TAGS = [
+  'h1', 'h2', 'h3', 'p', 'strong', 'b', 'em', 'i', 'br',
+  'ul', 'ol', 'li', 'table', 'tr', 'th', 'td', 'img', 'hr',
+];
+
+function sanitizeHtmlForPdf(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags: PDF_ALLOWED_TAGS,
+    allowedAttributes: { img: ['src'] },
+    allowedSchemes: ['data'],
+    allowedSchemesByTag: { img: ['data'] },
+    allowProtocolRelative: false,
+  });
+}
+
 /**
- * Renders HTML content to a PDF by stripping tags and using pdfkit.
+ * Renders a sanitized subset of HTML to PDF using PDFKit.
+ * Supports headings, paragraphs, inline emphasis, lists, tables, and data-URI images.
  * @param html - HTML content
  * @param outputPath - Destination file path
  * @returns Promise that resolves when the PDF is written
@@ -180,7 +196,7 @@ export function renderHtmlToPdf(html: string, outputPath: string): Promise<void>
 
     try {
       doc.pipe(stream);
-      const root = new DOMParser().parseFromString(`<root>${html}</root>`, 'text/html').documentElement;
+      const root = new DOMParser().parseFromString(`<root>${sanitizeHtmlForPdf(html)}</root>`, 'text/html').documentElement;
       const width = doc.page.width - 100;
       for (const child of Array.from(root.childNodes || [])) renderBlock(doc, child, width);
       doc.end();

--- a/packages/core/src/adapters/office/office-adapter.ts
+++ b/packages/core/src/adapters/office/office-adapter.ts
@@ -59,7 +59,7 @@ export class OfficeAdapter extends BaseAdapter {
 
       if (outputFmt === 'pdf') {
         logger.warn(
-          'PDF output uses basic text rendering. Formatting, images, and tables will not be preserved. For best results, convert to HTML instead.'
+          'PDF output preserves basic headings, paragraphs, lists, tables, and embedded images. Complex layouts and CSS are not preserved.'
         );
       }
 
@@ -125,7 +125,13 @@ export class OfficeAdapter extends BaseAdapter {
    * Preserves headings, lists, tables, bold/italic, and images.
    */
   private async readDocx(filePath: string): Promise<string> {
-    const result = await mammoth.convertToHtml({ path: filePath });
+    const result = await mammoth.convertToHtml({ path: filePath }, {
+      convertImage: mammoth.images.imgElement((image) =>
+        image.readAsBase64String().then((base64) => ({
+          src: `data:${image.contentType};base64,${base64}`,
+        }))
+      ),
+    });
 
     if (result.messages.length > 0) {
       logger.debug('Mammoth conversion messages', {

--- a/packages/core/test/html-renderers.test.ts
+++ b/packages/core/test/html-renderers.test.ts
@@ -1,4 +1,7 @@
-import { stripHtml } from '../src/adapters/document/html-renderers';
+import fs from 'fs';
+import sharp from 'sharp';
+import { getTestFilePath } from './setup';
+import { renderHtmlToPdf, stripHtml } from '../src/adapters/document/html-renderers';
 
 describe('stripHtml', () => {
   it('removes basic HTML tags', () => {
@@ -50,5 +53,19 @@ describe('stripHtml', () => {
     const result = stripHtml('<style>body{color:red}</style>text');
     expect(result).not.toContain('<style');
     expect(result).toBe('text');
+  });
+  it('renders semantic structure and embedded images instead of a text-only PDF', async () => {
+    const outputPath = getTestFilePath('structured-html-output.pdf');
+    const image = (await sharp({ create: { width: 20, height: 20, channels: 3, background: '#0a84ff' } }).png().toBuffer()).toString('base64');
+
+    await renderHtmlToPdf(
+      `<h1>Structured Heading</h1><p><strong>Bold</strong> and <em>italic</em> text.</p><ul><li>First item</li><li>Second item</li></ul><table><tr><th>Key</th><th>Value</th></tr><tr><td>Table</td><td>Value</td></tr></table><img src="data:image/png;base64,${image}">`,
+      outputPath
+    );
+
+    const pdf = fs.readFileSync(outputPath);
+    expect(pdf.subarray(0, 4).toString()).toBe('%PDF');
+    expect(pdf.includes(Buffer.from('/Subtype /Image'))).toBe(true);
+    expect(pdf.length).toBeGreaterThan(2_000);
   });
 });

--- a/packages/core/test/html-renderers.test.ts
+++ b/packages/core/test/html-renderers.test.ts
@@ -1,4 +1,6 @@
 import fs from 'fs';
+import path from 'path';
+import PDFDocument from 'pdfkit';
 import sharp from 'sharp';
 import { getTestFilePath } from './setup';
 import { renderHtmlToPdf, stripHtml } from '../src/adapters/document/html-renderers';
@@ -67,5 +69,38 @@ describe('stripHtml', () => {
     expect(pdf.subarray(0, 4).toString()).toBe('%PDF');
     expect(pdf.includes(Buffer.from('/Subtype /Image'))).toBe(true);
     expect(pdf.length).toBeGreaterThan(2_000);
+  });
+
+  it('uses the bold-oblique font for nested strong and emphasis tags', async () => {
+    const outputPath = getTestFilePath('nested-inline-styles.pdf');
+
+    await renderHtmlToPdf('<p><strong><em>Bold italic</em></strong></p>', outputPath);
+
+    expect(fs.readFileSync(outputPath).includes(Buffer.from('Helvetica-BoldOblique'))).toBe(true);
+  });
+
+  it('measures table cells using the table font size after a heading', async () => {
+    const outputPath = getTestFilePath('table-font-size.pdf');
+    const originalHeightOfString = PDFDocument.prototype.heightOfString;
+    const fontSizes: number[] = [];
+
+    PDFDocument.prototype.heightOfString = function (...args) {
+      fontSizes.push((this as PDFDocument & { _fontSize: number })._fontSize);
+      return originalHeightOfString.apply(this, args as [string, PDFKit.Mixins.TextOptions]);
+    };
+
+    try {
+      await renderHtmlToPdf('<h1>Heading</h1><table><tr><td>Cell</td></tr></table>', outputPath);
+    } finally {
+      PDFDocument.prototype.heightOfString = originalHeightOfString;
+    }
+
+    expect(fontSizes).toEqual([10]);
+  });
+
+  it('rejects when the output file cannot be created', async () => {
+    const outputPath = path.join(getTestFilePath('missing-output-directory'), 'output.pdf');
+
+    await expect(renderHtmlToPdf('<p>Content</p>', outputPath)).rejects.toThrow();
   });
 });

--- a/packages/core/test/html-renderers.test.ts
+++ b/packages/core/test/html-renderers.test.ts
@@ -5,6 +5,16 @@ import sharp from 'sharp';
 import { getTestFilePath } from './setup';
 import { renderHtmlToPdf, stripHtml } from '../src/adapters/document/html-renderers';
 
+async function extractPdfText(outputPath: string): Promise<string> {
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const document = await pdfjs.getDocument({ data: new Uint8Array(fs.readFileSync(outputPath)) }).promise;
+  const pages = await Promise.all(Array.from({ length: document.numPages }, async (_, index) => {
+    const content = await (await document.getPage(index + 1)).getTextContent();
+    return content.items.map((item) => ('str' in item ? item.str : '')).join('');
+  }));
+  return pages.join('\n');
+}
+
 describe('stripHtml', () => {
   it('removes basic HTML tags', () => {
     expect(stripHtml('<p>Hello</p>')).toBe('Hello');
@@ -102,5 +112,16 @@ describe('stripHtml', () => {
     const outputPath = path.join(getTestFilePath('missing-output-directory'), 'output.pdf');
 
     await expect(renderHtmlToPdf('<p>Content</p>', outputPath)).rejects.toThrow();
+  });
+
+  it('does not render content from unsupported tags', async () => {
+    const outputPath = getTestFilePath('unsupported-html-output.pdf');
+
+    await renderHtmlToPdf('<p>Visible content</p><script>SECRET_SCRIPT</script><style>SECRET_STYLE</style>', outputPath);
+
+    const text = await extractPdfText(outputPath);
+    expect(text).toContain('Visible content');
+    expect(text).not.toContain('SECRET_SCRIPT');
+    expect(text).not.toContain('SECRET_STYLE');
   });
 });


### PR DESCRIPTION
## Summary

- Render DOCX/office HTML into PDFs with headings, paragraphs, lists, tables, inline emphasis, and data-URI images preserved.
- Configure Mammoth to embed DOCX images as data URIs before PDF rendering.
- Route direct Markdown and HTML PDF conversions through the same structured renderer.

## Root Cause

`renderHtmlToPdf` stripped every HTML tag before invoking PDFKit, so office conversion lost all semantic structure and images. Mammoth's default image conversion also did not provide PDFKit with an embeddable image source.

## Validation

- `npm.cmd test` (130 tests)
- `npm.cmd run lint`
- `npm.cmd run build -w @fileconverter/core`
- `npm.cmd audit --workspaces` (0 vulnerabilities)

Closes #32
