### PR TITLE
fix: prefer LibreOffice for office PDF output

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,6 +46,8 @@ converter pdf --split thesis.pdf --pages 1-5,10 -o excerpt.pdf
 converter ocr -i scan.png -o result.txt --lang eng
 ```
 
+> Office-to-PDF conversions automatically use LibreOffice when it is installed, which preserves document layout more faithfully. Without LibreOffice, FileConverter uses a semantic npm fallback that preserves basic content but not complex layout, fonts, or positioning. Set `LIBREOFFICE_PATH` to use an executable outside the standard install locations.
+
 ## Supported Formats
 
 | Category | Input | Output |

--- a/packages/core/src/adapters/office/libreoffice-renderer.ts
+++ b/packages/core/src/adapters/office/libreoffice-renderer.ts
@@ -1,0 +1,90 @@
+import { execFile as execFileCallback } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { promisify } from 'util';
+
+const execFile = promisify(execFileCallback);
+
+export type LibreOfficeRunner = (command: string, args: string[]) => Promise<void>;
+
+export interface LibreOfficeOptions {
+  environment?: NodeJS.ProcessEnv;
+  executablePaths?: string[];
+  platform?: NodeJS.Platform;
+  run?: LibreOfficeRunner;
+}
+
+function defaultExecutablePaths(platform: NodeJS.Platform, environment: NodeJS.ProcessEnv): string[] {
+  const executable = platform === 'win32' ? 'soffice.exe' : 'soffice';
+  const pathEntries = (environment.PATH || '').split(path.delimiter).filter(Boolean);
+  const pathCandidates = pathEntries.map((entry) => path.join(entry, executable));
+
+  if (platform === 'win32') {
+    return [
+      ...pathCandidates,
+      path.join(environment.ProgramFiles || 'C:\\Program Files', 'LibreOffice', 'program', executable),
+      path.join(environment['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'LibreOffice', 'program', executable),
+    ];
+  }
+
+  if (platform === 'darwin') {
+    return [...pathCandidates, '/Applications/LibreOffice.app/Contents/MacOS/soffice'];
+  }
+
+  return [...pathCandidates, '/usr/bin/soffice', '/usr/local/bin/soffice'];
+}
+
+export function findLibreOfficeExecutable(options: LibreOfficeOptions = {}): string | undefined {
+  const environment = options.environment || process.env;
+  const platform = options.platform || process.platform;
+  const candidates = [
+    environment.LIBREOFFICE_PATH,
+    ...(options.executablePaths || defaultExecutablePaths(platform, environment)),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+async function runLibreOffice(command: string, args: string[]): Promise<void> {
+  await execFile(command, args, { timeout: 120_000, windowsHide: true });
+}
+
+export async function renderOfficeToPdfWithLibreOffice(
+  inputPath: string,
+  outputPath: string,
+  options: LibreOfficeOptions = {}
+): Promise<boolean> {
+  const executable = findLibreOfficeExecutable(options);
+  if (!executable) return false;
+
+  const temporaryRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'fileconverter-libreoffice-'));
+  const profileDirectory = path.join(temporaryRoot, 'profile');
+  const outputDirectory = path.join(temporaryRoot, 'output');
+  const generatedPdf = path.join(outputDirectory, `${path.parse(inputPath).name}.pdf`);
+
+  try {
+    await fs.promises.mkdir(profileDirectory);
+    await fs.promises.mkdir(outputDirectory);
+    await (options.run || runLibreOffice)(executable, [
+      '--headless',
+      `-env:UserInstallation=${pathToFileURL(profileDirectory).href}`,
+      '--convert-to',
+      'pdf:writer_pdf_Export',
+      '--outdir',
+      outputDirectory,
+      inputPath,
+    ]);
+
+    if (!fs.existsSync(generatedPdf)) {
+      throw new Error('LibreOffice completed without creating a PDF file');
+    }
+
+    await fs.promises.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.promises.copyFile(generatedPdf, outputPath);
+    return true;
+  } finally {
+    await fs.promises.rm(temporaryRoot, { recursive: true, force: true });
+  }
+}

--- a/packages/core/src/adapters/office/office-adapter.ts
+++ b/packages/core/src/adapters/office/office-adapter.ts
@@ -14,11 +14,15 @@ import {
   wrapInHtmlDocument,
   htmlToMarkdown,
 } from '../document/html-renderers';
+import { renderOfficeToPdfWithLibreOffice } from './libreoffice-renderer';
+
+type OfficePdfRenderer = (inputPath: string, outputPath: string) => Promise<boolean>;
 
 /**
- * Office document adapter using pure JavaScript libraries.
- * Converts DOCX, XLSX, PPTX, ODT, and RTF without external system programs.
+ * Office document adapter using LibreOffice when available, with npm fallbacks.
+ * Converts DOCX, XLSX, PPTX, ODT, and RTF to PDF with LibreOffice for layout fidelity.
  *
+ * - LibreOffice: Office -> PDF (when installed)
  * - mammoth: DOCX -> HTML (semantic, preserves headings/lists/tables/images)
  * - JSZip + XML parsing: XLSX -> HTML tables
  * - officeparser: PPTX/ODT/RTF -> plain text extraction
@@ -27,6 +31,10 @@ export class OfficeAdapter extends BaseAdapter {
   readonly name = 'office';
   readonly supportedInputFormats = ['docx', 'xlsx', 'pptx', 'odt', 'rtf'];
   readonly supportedOutputFormats = ['pdf', 'html', 'txt', 'md'];
+
+  constructor(private readonly renderOfficeToPdf: OfficePdfRenderer = renderOfficeToPdfWithLibreOffice) {
+    super();
+  }
 
   async convert(
     plan: ConversionPlan,
@@ -57,14 +65,25 @@ export class OfficeAdapter extends BaseAdapter {
         outputFormat: outputFmt,
       });
 
+      let renderedByLibreOffice = false;
       if (outputFmt === 'pdf') {
-        logger.warn(
-          'PDF output preserves basic headings, paragraphs, lists, tables, and embedded images. Complex layouts and CSS are not preserved.'
-        );
+        renderedByLibreOffice = await this.renderOfficeToPdf(plan.inputPath, plan.outputPath);
       }
 
-      const html = await this.readToHtml(plan.inputPath, inputFmt);
-      await this.writeOutput(html, outputFmt, plan.outputPath);
+      if (renderedByLibreOffice) {
+        logger.debug('Office adapter: PDF rendered with LibreOffice', {
+          input: plan.inputPath,
+          output: plan.outputPath,
+        });
+      } else {
+        if (outputFmt === 'pdf') {
+          logger.warn(
+            'LibreOffice was not found. PDF output uses semantic fallback rendering; complex layouts, fonts, and positioning are not preserved.'
+          );
+        }
+        const html = await this.readToHtml(plan.inputPath, inputFmt);
+        await this.writeOutput(html, outputFmt, plan.outputPath);
+      }
 
       const duration = Date.now() - startTime;
       const outputSize = fs.existsSync(plan.outputPath) ? fs.statSync(plan.outputPath).size : 0;

--- a/packages/core/test/adapters/libreoffice-renderer.test.ts
+++ b/packages/core/test/adapters/libreoffice-renderer.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+import { getTestFilePath } from '../setup';
+import {
+  findLibreOfficeExecutable,
+  renderOfficeToPdfWithLibreOffice,
+} from '../../src/adapters/office/libreoffice-renderer';
+
+describe('LibreOffice PDF renderer', () => {
+  it('uses LIBREOFFICE_PATH when it points to an existing executable', () => {
+    const executable = getTestFilePath('soffice.exe');
+    fs.writeFileSync(executable, '');
+
+    expect(findLibreOfficeExecutable({
+      environment: { LIBREOFFICE_PATH: executable },
+      executablePaths: [],
+    })).toBe(executable);
+  });
+
+  it('reports LibreOffice as unavailable when no candidate exists', () => {
+    expect(findLibreOfficeExecutable({
+      environment: {},
+      executablePaths: [],
+    })).toBeUndefined();
+  });
+
+  it('writes LibreOffice output to the requested PDF path', async () => {
+    const executable = getTestFilePath('soffice.exe');
+    const inputPath = getTestFilePath('resume.docx');
+    const outputPath = getTestFilePath('custom-name.pdf');
+    fs.writeFileSync(executable, '');
+    fs.writeFileSync(inputPath, 'docx content');
+
+    const converted = await renderOfficeToPdfWithLibreOffice(inputPath, outputPath, {
+      environment: { LIBREOFFICE_PATH: executable },
+      executablePaths: [],
+      run: async (_command, args) => {
+        const outputDirectory = args[args.indexOf('--outdir') + 1];
+        fs.writeFileSync(path.join(outputDirectory, 'resume.pdf'), '%PDF-1.7');
+      },
+    });
+
+    expect(converted).toBe(true);
+    expect(fs.readFileSync(outputPath, 'utf-8')).toBe('%PDF-1.7');
+  });
+});

--- a/packages/core/test/adapters/office-adapter.test.ts
+++ b/packages/core/test/adapters/office-adapter.test.ts
@@ -170,6 +170,61 @@ describe('OfficeAdapter', () => {
         expect(fs.statSync(outputPath).size).toBeGreaterThan(0);
       });
 
+      it('uses LibreOffice output when the renderer is available', async () => {
+        const inputPath = getTestFilePath('libreoffice-input.docx');
+        const outputPath = getTestFilePath('libreoffice-output.pdf');
+        fs.writeFileSync(inputPath, 'not a DOCX file');
+        const libreOfficeAdapter = new OfficeAdapter(async (_input, output) => {
+          fs.writeFileSync(output, '%PDF-libreoffice');
+          return true;
+        });
+
+        const result = await libreOfficeAdapter.convert({
+          inputPath,
+          outputPath,
+          inputFormat: 'docx',
+          outputFormat: 'pdf',
+          supported: true,
+        }, {});
+
+        expect(result.success).toBe(true);
+        expect(fs.readFileSync(outputPath, 'utf-8')).toBe('%PDF-libreoffice');
+      });
+
+      it('falls back to semantic PDF rendering when LibreOffice is unavailable', async () => {
+        const outputPath = getTestFilePath('docx-fallback-output.pdf');
+        const fallbackAdapter = new OfficeAdapter(async () => false);
+
+        const result = await fallbackAdapter.convert({
+          inputPath: testDocxPath,
+          outputPath,
+          inputFormat: 'docx',
+          outputFormat: 'pdf',
+          supported: true,
+        }, {});
+
+        expect(result.success).toBe(true);
+        expect(fs.readFileSync(outputPath).subarray(0, 4).toString()).toBe('%PDF');
+      });
+
+      it('returns a failed conversion when LibreOffice rendering fails', async () => {
+        const outputPath = getTestFilePath('docx-libreoffice-error.pdf');
+        const failingAdapter = new OfficeAdapter(async () => {
+          throw new Error('LibreOffice failed');
+        });
+
+        const result = await failingAdapter.convert({
+          inputPath: testDocxPath,
+          outputPath,
+          inputFormat: 'docx',
+          outputFormat: 'pdf',
+          supported: true,
+        }, {});
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('LibreOffice failed');
+      });
+
       it('should convert docx to md', async () => {
         const outputPath = getTestFilePath('docx-output.md');
         const plan = {


### PR DESCRIPTION
## Summary

- Prefer LibreOffice for all Office-to-PDF conversions when it is installed.
- Use an isolated LibreOffice profile and temporary output directory for every conversion job.
- Retain the semantic npm PDF renderer only when LibreOffice is unavailable.
- Document the rendering behavior and `LIBREOFFICE_PATH` override.

## Root Cause

The prior DOCX-to-PDF path converted Word files through Mammoth's semantic HTML output and then PDFKit. Mammoth intentionally discards layout-specific Word information, so CVs and other formatted documents could not retain their original appearance.

## Validation

- `npm.cmd test` (140 tests)
- `npm.cmd run lint`
- `npm.cmd run build`
- `npm.cmd audit --workspaces` (0 vulnerabilities)
- Converted the supplied CV through the local CLI: LibreOffice output was 131,273 bytes, replacing the prior 2,796-byte semantic PDF.
