### PR TITLE
fix: prefer Microsoft Word for document PDFs

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,7 +46,7 @@ converter pdf --split thesis.pdf --pages 1-5,10 -o excerpt.pdf
 converter ocr -i scan.png -o result.txt --lang eng
 ```
 
-> Office-to-PDF conversions automatically use LibreOffice when it is installed, which preserves document layout more faithfully. Without LibreOffice, FileConverter uses a semantic npm fallback that preserves basic content but not complex layout, fonts, or positioning. Set `LIBREOFFICE_PATH` to use an executable outside the standard install locations.
+> Office-to-PDF conversions prefer Microsoft Word for DOCX and RTF files on Windows, then LibreOffice for all supported Office formats. Both preserve document layout more faithfully than the semantic npm fallback. Set `MICROSOFT_WORD_PATH` or `LIBREOFFICE_PATH` to use executables outside the standard install locations. Without either application, FileConverter preserves basic content but not complex layout, fonts, or positioning.
 
 ## Supported Formats
 

--- a/packages/core/src/adapters/office/microsoft-word-renderer.ts
+++ b/packages/core/src/adapters/office/microsoft-word-renderer.ts
@@ -1,0 +1,115 @@
+import { execFile as execFileCallback } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+
+const execFile = promisify(execFileCallback);
+
+export type MicrosoftWordRunner = (scriptPath: string, inputPath: string, outputPath: string) => Promise<void>;
+
+export interface MicrosoftWordOptions {
+  environment?: NodeJS.ProcessEnv;
+  executablePaths?: string[];
+  platform?: NodeJS.Platform;
+  run?: MicrosoftWordRunner;
+}
+
+function defaultExecutablePaths(environment: NodeJS.ProcessEnv): string[] {
+  const programFiles = [
+    environment.ProgramFiles || 'C:\\Program Files',
+    environment['ProgramFiles(x86)'] || 'C:\\Program Files (x86)',
+  ];
+  const versions = ['Office16', 'Office15', 'Office14', 'Office12'];
+  const pathCandidates = (environment.PATH || '')
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((entry) => path.join(entry, 'WINWORD.EXE'));
+
+  return [
+    ...pathCandidates,
+    ...programFiles.flatMap((programFilesPath) => versions.flatMap((version) => [
+      path.join(programFilesPath, 'Microsoft Office', 'root', version, 'WINWORD.EXE'),
+      path.join(programFilesPath, 'Microsoft Office', version, 'WINWORD.EXE'),
+    ])),
+  ];
+}
+
+export function findMicrosoftWordExecutable(options: MicrosoftWordOptions = {}): string | undefined {
+  const environment = options.environment || process.env;
+  const platform = options.platform || process.platform;
+  if (platform !== 'win32') return undefined;
+
+  const candidates = [
+    environment.MICROSOFT_WORD_PATH,
+    ...(options.executablePaths || defaultExecutablePaths(environment)),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function wordAutomationScript(): string {
+  return [
+    'param([string]$InputPath, [string]$OutputPath)',
+    '$word = $null',
+    '$document = $null',
+    'try {',
+    '  $word = New-Object -ComObject Word.Application',
+    '  $word.Visible = $false',
+    '  $word.DisplayAlerts = 0',
+    '  $document = $word.Documents.Open($InputPath, $false, $true)',
+    '  $document.ExportAsFixedFormat($OutputPath, 17)',
+    '  if (-not (Test-Path -LiteralPath $OutputPath)) { throw "Microsoft Word did not create a PDF file" }',
+    '} finally {',
+    '  if ($document -ne $null) { $document.Close($false) }',
+    '  if ($word -ne $null) { $word.Quit() }',
+    '}',
+  ].join('\r\n');
+}
+
+async function runMicrosoftWord(scriptPath: string, inputPath: string, outputPath: string): Promise<void> {
+  const powershellPath = path.join(
+    process.env.SystemRoot || 'C:\\Windows',
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe'
+  );
+  const command = fs.existsSync(powershellPath) ? powershellPath : 'powershell.exe';
+  await execFile(command, [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Sta',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-File',
+    scriptPath,
+    inputPath,
+    outputPath,
+  ], { timeout: 120_000, windowsHide: true });
+}
+
+export async function renderOfficeToPdfWithMicrosoftWord(
+  inputPath: string,
+  outputPath: string,
+  options: MicrosoftWordOptions = {}
+): Promise<boolean> {
+  if (!findMicrosoftWordExecutable(options)) return false;
+
+  const temporaryRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'fileconverter-word-'));
+  const scriptPath = path.join(temporaryRoot, 'convert-to-pdf.ps1');
+
+  try {
+    await fs.promises.writeFile(scriptPath, wordAutomationScript(), 'utf-8');
+    await fs.promises.mkdir(path.dirname(outputPath), { recursive: true });
+    await (options.run || runMicrosoftWord)(scriptPath, inputPath, outputPath);
+
+    if (!fs.existsSync(outputPath)) {
+      throw new Error('Microsoft Word completed without creating a PDF file');
+    }
+
+    return true;
+  } finally {
+    await fs.promises.rm(temporaryRoot, { recursive: true, force: true });
+  }
+}

--- a/packages/core/src/adapters/office/office-adapter.ts
+++ b/packages/core/src/adapters/office/office-adapter.ts
@@ -15,13 +15,15 @@ import {
   htmlToMarkdown,
 } from '../document/html-renderers';
 import { renderOfficeToPdfWithLibreOffice } from './libreoffice-renderer';
+import { renderOfficeToPdfWithMicrosoftWord } from './microsoft-word-renderer';
 
 type OfficePdfRenderer = (inputPath: string, outputPath: string) => Promise<boolean>;
 
 /**
- * Office document adapter using LibreOffice when available, with npm fallbacks.
- * Converts DOCX, XLSX, PPTX, ODT, and RTF to PDF with LibreOffice for layout fidelity.
+ * Office document adapter using Microsoft Word and LibreOffice when available.
+ * Converts Office documents to PDF with the highest-fidelity available renderer.
  *
+ * - Microsoft Word: DOCX/RTF -> PDF (Windows, when installed)
  * - LibreOffice: Office -> PDF (when installed)
  * - mammoth: DOCX -> HTML (semantic, preserves headings/lists/tables/images)
  * - JSZip + XML parsing: XLSX -> HTML tables
@@ -32,7 +34,10 @@ export class OfficeAdapter extends BaseAdapter {
   readonly supportedInputFormats = ['docx', 'xlsx', 'pptx', 'odt', 'rtf'];
   readonly supportedOutputFormats = ['pdf', 'html', 'txt', 'md'];
 
-  constructor(private readonly renderOfficeToPdf: OfficePdfRenderer = renderOfficeToPdfWithLibreOffice) {
+  constructor(
+    private readonly renderWithMicrosoftWord: OfficePdfRenderer = renderOfficeToPdfWithMicrosoftWord,
+    private readonly renderWithLibreOffice: OfficePdfRenderer = renderOfficeToPdfWithLibreOffice
+  ) {
     super();
   }
 
@@ -65,20 +70,20 @@ export class OfficeAdapter extends BaseAdapter {
         outputFormat: outputFmt,
       });
 
-      let renderedByLibreOffice = false;
+      let pdfRenderer: string | undefined;
       if (outputFmt === 'pdf') {
-        renderedByLibreOffice = await this.renderOfficeToPdf(plan.inputPath, plan.outputPath);
+        pdfRenderer = await this.renderOfficePdf(plan.inputPath, inputFmt, plan.outputPath);
       }
 
-      if (renderedByLibreOffice) {
-        logger.debug('Office adapter: PDF rendered with LibreOffice', {
+      if (pdfRenderer) {
+        logger.debug(`Office adapter: PDF rendered with ${pdfRenderer}`, {
           input: plan.inputPath,
           output: plan.outputPath,
         });
       } else {
         if (outputFmt === 'pdf') {
           logger.warn(
-            'LibreOffice was not found. PDF output uses semantic fallback rendering; complex layouts, fonts, and positioning are not preserved.'
+            'No compatible external Office renderer was found. PDF output uses semantic fallback rendering; complex layouts, fonts, and positioning are not preserved.'
           );
         }
         const html = await this.readToHtml(plan.inputPath, inputFmt);
@@ -114,6 +119,14 @@ export class OfficeAdapter extends BaseAdapter {
 
       return { success: false, outputPath: plan.outputPath, duration, error: errorMessage };
     }
+  }
+
+  private async renderOfficePdf(inputPath: string, inputFormat: string, outputPath: string): Promise<string | undefined> {
+    if (inputFormat === 'docx' || inputFormat === 'rtf') {
+      if (await this.renderWithMicrosoftWord(inputPath, outputPath)) return 'Microsoft Word';
+    }
+    if (await this.renderWithLibreOffice(inputPath, outputPath)) return 'LibreOffice';
+    return undefined;
   }
 
   /**

--- a/packages/core/test/adapters/microsoft-word-renderer.test.ts
+++ b/packages/core/test/adapters/microsoft-word-renderer.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import { getTestFilePath } from '../setup';
+import {
+  findMicrosoftWordExecutable,
+  renderOfficeToPdfWithMicrosoftWord,
+} from '../../src/adapters/office/microsoft-word-renderer';
+
+describe('Microsoft Word PDF renderer', () => {
+  it('uses MICROSOFT_WORD_PATH on Windows when it points to Word', () => {
+    const executable = getTestFilePath('WINWORD.EXE');
+    fs.writeFileSync(executable, '');
+
+    expect(findMicrosoftWordExecutable({
+      platform: 'win32',
+      environment: { MICROSOFT_WORD_PATH: executable },
+      executablePaths: [],
+    })).toBe(executable);
+  });
+
+  it('reports Word as unavailable outside Windows', () => {
+    const executable = getTestFilePath('WINWORD.EXE');
+    fs.writeFileSync(executable, '');
+
+    expect(findMicrosoftWordExecutable({
+      platform: 'linux',
+      environment: { MICROSOFT_WORD_PATH: executable },
+      executablePaths: [],
+    })).toBeUndefined();
+  });
+
+  it('writes Word output to the requested PDF path', async () => {
+    const executable = getTestFilePath('WINWORD.EXE');
+    const inputPath = getTestFilePath('resume.docx');
+    const outputPath = getTestFilePath('resume-output.pdf');
+    fs.writeFileSync(executable, '');
+    fs.writeFileSync(inputPath, 'docx content');
+
+    const converted = await renderOfficeToPdfWithMicrosoftWord(inputPath, outputPath, {
+      platform: 'win32',
+      environment: { MICROSOFT_WORD_PATH: executable },
+      executablePaths: [],
+      run: async (scriptPath, _inputPath, requestedOutputPath) => {
+        const script = fs.readFileSync(scriptPath, 'utf-8');
+        expect(script).toContain('New-Object -ComObject Word.Application');
+        expect(script).toContain('ExportAsFixedFormat');
+        fs.writeFileSync(requestedOutputPath, '%PDF-word');
+      },
+    });
+
+    expect(converted).toBe(true);
+    expect(fs.readFileSync(outputPath, 'utf-8')).toBe('%PDF-word');
+  });
+});

--- a/packages/core/test/adapters/office-adapter.test.ts
+++ b/packages/core/test/adapters/office-adapter.test.ts
@@ -170,17 +170,44 @@ describe('OfficeAdapter', () => {
         expect(fs.statSync(outputPath).size).toBeGreaterThan(0);
       });
 
-      it('uses LibreOffice output when the renderer is available', async () => {
+      it('uses Microsoft Word output before LibreOffice for DOCX files', async () => {
         const inputPath = getTestFilePath('libreoffice-input.docx');
         const outputPath = getTestFilePath('libreoffice-output.pdf');
         fs.writeFileSync(inputPath, 'not a DOCX file');
-        const libreOfficeAdapter = new OfficeAdapter(async (_input, output) => {
-          fs.writeFileSync(output, '%PDF-libreoffice');
-          return true;
-        });
+        const wordAdapter = new OfficeAdapter(
+          async (_input, output) => {
+            fs.writeFileSync(output, '%PDF-word');
+            return true;
+          },
+          async () => {
+            throw new Error('LibreOffice should not run after a Word conversion');
+          }
+        );
+
+        const result = await wordAdapter.convert({
+          inputPath,
+          outputPath,
+          inputFormat: 'docx',
+          outputFormat: 'pdf',
+          supported: true,
+        }, {});
+
+        expect(result.success).toBe(true);
+        expect(fs.readFileSync(outputPath, 'utf-8')).toBe('%PDF-word');
+      });
+
+      it('uses LibreOffice when Microsoft Word is unavailable', async () => {
+        const outputPath = getTestFilePath('docx-libreoffice-output.pdf');
+        const libreOfficeAdapter = new OfficeAdapter(
+          async () => false,
+          async (_input, output) => {
+            fs.writeFileSync(output, '%PDF-libreoffice');
+            return true;
+          }
+        );
 
         const result = await libreOfficeAdapter.convert({
-          inputPath,
+          inputPath: testDocxPath,
           outputPath,
           inputFormat: 'docx',
           outputFormat: 'pdf',
@@ -191,9 +218,9 @@ describe('OfficeAdapter', () => {
         expect(fs.readFileSync(outputPath, 'utf-8')).toBe('%PDF-libreoffice');
       });
 
-      it('falls back to semantic PDF rendering when LibreOffice is unavailable', async () => {
+      it('falls back to semantic PDF rendering when no external renderer is available', async () => {
         const outputPath = getTestFilePath('docx-fallback-output.pdf');
-        const fallbackAdapter = new OfficeAdapter(async () => false);
+        const fallbackAdapter = new OfficeAdapter(async () => false, async () => false);
 
         const result = await fallbackAdapter.convert({
           inputPath: testDocxPath,
@@ -209,9 +236,12 @@ describe('OfficeAdapter', () => {
 
       it('returns a failed conversion when LibreOffice rendering fails', async () => {
         const outputPath = getTestFilePath('docx-libreoffice-error.pdf');
-        const failingAdapter = new OfficeAdapter(async () => {
-          throw new Error('LibreOffice failed');
-        });
+        const failingAdapter = new OfficeAdapter(
+          async () => false,
+          async () => {
+            throw new Error('LibreOffice failed');
+          }
+        );
 
         const result = await failingAdapter.convert({
           inputPath: testDocxPath,


### PR DESCRIPTION
## Summary

- Prefer Microsoft Word COM automation for DOCX and RTF PDF conversions on Windows.
- Fall back to LibreOffice for every supported Office format when Word is unavailable.
- Keep the semantic npm renderer only when neither external Office application is available.
- Document `MICROSOFT_WORD_PATH` and the rendering priority.

## Root Cause

LibreOffice provides a good layout-preserving PDF path, but Windows users with Microsoft Office installed were not using Word's native rendering engine.

## Validation

- `npm.cmd test` (144 tests)
- `npm.cmd run lint`
- `npm.cmd run build`
- `npm.cmd audit --workspaces` (0 vulnerabilities)
- Converted the supplied CV through the local CLI; LibreOffice fallback produced a 131,273-byte PDF on this machine.
