### PR TITLE
fix: honor explicit CLI output file paths

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -101,7 +101,8 @@ program
 
       const convertOptions: ConversionOptions = {
         input: input!,
-        output: options.out,
+        output: path.dirname(options.out),
+        outputFile: options.out,
         format: 'pdf',
         operation,
         pages: options.pages,
@@ -128,7 +129,8 @@ program
 
       await converter.convert({
         input: options.in,
-        output: options.out,
+        output: path.dirname(options.out),
+        outputFile: options.out,
         format: 'txt',
         language: options.lang,
       });

--- a/packages/core/src/converter.ts
+++ b/packages/core/src/converter.ts
@@ -16,6 +16,7 @@ export class Converter {
     const { 
       input, 
       output, 
+      outputFile,
       format, 
       recursive = false, 
       dryRun = false,
@@ -44,7 +45,8 @@ export class Converter {
     });
     
     try {
-      const resolvedOutput = path.resolve(output);
+      const outputDirectory = outputFile ? path.dirname(outputFile) : output;
+      const resolvedOutput = path.resolve(outputDirectory);
 
       if (!fs.existsSync(resolvedOutput)) {
         fs.mkdirSync(resolvedOutput, { recursive: true });
@@ -52,7 +54,16 @@ export class Converter {
       }
       
       // Scan for files and create conversion plan
-      const plans = await scanForFiles(input, output, format, recursive);
+      const plans = await scanForFiles(input, resolvedOutput, format, recursive);
+
+      if (outputFile) {
+        if (plans.length !== 1) {
+          throw new Error('An explicit output file requires exactly one input file');
+        }
+
+        const resolvedOutputFile = validatePath(outputFile, resolvedOutput);
+        plans[0].outputPath = resolvedOutputFile;
+      }
       
       if (plans.length === 0) {
         logger.warn('No files found for conversion');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,6 +10,8 @@ export interface ConversionPlan {
 export interface ConversionOptions {
   input: string;
   output: string;
+  /** Exact destination for single-file conversions. */
+  outputFile?: string;
   format: string;
   recursive?: boolean;
   dryRun?: boolean;

--- a/packages/core/test/integration/converter.test.ts
+++ b/packages/core/test/integration/converter.test.ts
@@ -93,6 +93,26 @@ describe('Converter Integration Tests', () => {
     }, 60000);
   });
 
+  describe('Explicit Output Files', () => {
+    it('writes a single conversion to the requested output file', async () => {
+      const inputFile = path.join(testInputDir, 'source.md');
+      const outputFile = path.join(testOutputDir, 'requested-name.html');
+      fs.writeFileSync(inputFile, '# Explicit output file');
+
+      const result = await converter.convert({
+        input: inputFile,
+        output: testOutputDir,
+        outputFile,
+        format: 'html',
+      });
+
+      expect(result.successfulJobs).toBe(1);
+      expect(fs.existsSync(outputFile)).toBe(true);
+      expect(fs.statSync(outputFile).isFile()).toBe(true);
+      expect(fs.existsSync(path.join(outputFile, 'source.html'))).toBe(false);
+    });
+  });
+
   describe('Error Handling', () => {
     it('should handle non-existent input directory', async () => {
       const nonExistentDir = path.join(testInputDir, 'non-existent');


### PR DESCRIPTION
## Description

Fixes the `pdf` and `ocr` CLI commands so `--out` writes to the exact file path supplied by the user instead of treating that path as an output directory.

The converter now supports a validated explicit output-file path for single-file conversions. The general `convert` command continues to use output directories.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] CI / build / tooling

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have added tests that prove my fix or feature works
- [x] All tests pass locally (`npm test` after `npm run build`)
- [x] Linting passes (`npm run lint`)
- [ ] I have updated documentation if needed

## Verification

- `npm run build`
- `npm test` - 145 tests passed
- `npm run lint`
- `npm audit --workspaces` - 0 vulnerabilities
- Manual CLI verification: PDF merge, split, compress, and OCR all created the requested output file.
