### PR TITLE
fix: upgrade pdfkit to remove jpeg-exif

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1798,6 +1798,30 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@pdf-lib/standard-fonts": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
@@ -3309,6 +3333,15 @@
         "base64-js": "^1.1.2"
       }
     },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
@@ -3492,12 +3525,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4307,11 +4334,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/jpeg-exif": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
-      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -5031,16 +5057,17 @@
       }
     },
     "node_modules/pdfkit": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.2.tgz",
-      "integrity": "sha512-UnwF5fXy08f0dnp4jchFYAROKMNTaPqb/xgR8GtCzIcqoTnbOqtp3bwKvO4688oHI6vzEEs8Q6vqqEnC5IUELw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.19.1.tgz",
+      "integrity": "sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==",
       "license": "MIT",
       "dependencies": {
-        "crypto-js": "^4.2.0",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
         "fontkit": "^2.0.4",
-        "jpeg-exif": "^1.1.4",
+        "js-md5": "^0.8.3",
         "linebreak": "^1.1.0",
-        "png-js": "^1.0.0"
+        "png-js": "^1.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -5073,9 +5100,12 @@
       }
     },
     "node_modules/png-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
-      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.24",
@@ -6549,7 +6579,7 @@
     },
     "packages/core": {
       "name": "@fileconverter/core",
-      "version": "1.4.0",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.13",
@@ -6564,7 +6594,7 @@
         "officeparser": "^7.5.0",
         "p-queue": "^9.1.0",
         "pdf-lib": "^1.17.1",
-        "pdfkit": "^0.17.2",
+        "pdfkit": "^0.19.1",
         "rtf.js": "^3.0.9",
         "sanitize-html": "^2.17.1",
         "sharp": "^0.35.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
     "officeparser": "^7.5.0",
     "p-queue": "^9.1.0",
     "pdf-lib": "^1.17.1",
-    "pdfkit": "^0.17.2",
+    "pdfkit": "^0.19.1",
     "rtf.js": "^3.0.9",
     "sanitize-html": "^2.17.1",
     "sharp": "^0.35.3",


### PR DESCRIPTION
## Description

Upgrades the core PDF rendering dependency from `pdfkit@0.17.2` to `pdfkit@0.19.1`.

This removes the deprecated transitive `jpeg-exif@1.1.4` package and therefore removes its installation warning. PDF generation remains compatible and was verified through the CLI.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] CI / build / tooling

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have added tests that prove my fix or feature works
- [x] All tests pass locally (`npm test` after `npm run build`)
- [x] Linting passes (`npm run lint`)
- [ ] I have updated documentation if needed

## Verification

- `npm ci` completes without the `jpeg-exif` deprecation warning.
- `npm explain jpeg-exif` reports no matching dependency.
- `npm run build`
- `npm test` - 145 tests passed
- `npm run lint`
- `npm audit --workspaces` - 0 vulnerabilities
- Manual Markdown-to-PDF CLI conversion produced a valid `%PDF-` file.
